### PR TITLE
Pass MinKNOW host when connecting to the minknow_api

### DIFF
--- a/read_until/base.py
+++ b/read_until/base.py
@@ -134,7 +134,7 @@ class ReadUntilClient(object):
         self.prefilter_classes = prefilter_classes
 
         try:
-            self.connection = Connection(self.mk_grpc_port)
+            self.connection = Connection(host=self.mk_host, port=self.mk_grpc_port)
         except:
             # FIXME: Broad exception
             logging.error(


### PR DESCRIPTION
MinKNOW host is not used when initialising the `minknow_api.Connection` in the read until client. 

It might also be worth adding the `use_tls` argument for the connection class. Not sure how this should be supplied though, perhaps another parameter for the read until client?